### PR TITLE
Touch ups for dictation issues in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,57 @@
 ﻿# Utilities-Terminal-Application-Bundle
-These are bundled ZIP packages that contain programs that most people would either half to pay for, like calculator software and other useful items. These are so called Terminal Applications because they are ment to be run in a terminal window or Python shell. Because of this, I can support people with disabilities without having to go through all of the hard work that is required when writing programs with a graphical user interface (GUI). If a blind person uses the command line or Linux terminal to open these scripts in Python, then they can easily follow the prompts on screen. Almost every screen reader that has the ability to work with the command line or Linux terminal should work. Note:  not all screen readers have been tested yet. Results may vary from screen reader to screen reader.  I’m currently working on a timer, a stopwatch and a basic simple calculater. Other calculators and conversion calculators are planned for the future.
 
-##How to run these applications.
-Make sure that you have an active Python installation on your computer. All these programs were written in the Python programming language. You will need to install the latest Python 2.7X version on your computer. It is also possible to run all of these scripts in iOS. You'll need to download an app with Python 2.7X or later. Then you will need to make sure that the app can open .py files from other apps. It is possible to store this repository onto your own personal Dropbox folder, so you can import them into your python app easily. Some apps might support ZIP files, in which case all you would need to do to open all the files at once is to open the zip package and unzip it with commands on the app. Please note: I wrote these files on a Windows 8.1 laptop. I don't know for sure if your other operating system will work with these programs, but I tried to iliminate all the modules that require a certain operating system.
+These are bundled ZIP packages that contain programs that most people
+would either have to pay for, like calculator software and other
+useful items. These are so called Terminal Applications because they
+are meant to be run in a terminal window or Python shell. Because of
+this, I can support people with disabilities without having to go
+through all of the hard work that is required when writing programs
+with a graphical user interface (GUI). If a blind person uses the
+command line or Linux terminal to open these scripts in Python, then
+they can easily follow the prompts on screen. Almost every screen
+reader that has the ability to work with the command line or Linux
+terminal should work. Note: not all screen readers have been tested
+yet. Results may vary from screen reader to screen reader.  I’m
+currently working on a timer, a stopwatch and a basic simple
+calculator. Other calculators and conversion calculators are planned
+for the future.
+
+##How to Run These Applications
+
+Make sure that you have an active Python installation on your
+computer. All these programs were written in the Python programming
+language. You will need to install the latest Python 2.7X version on
+your computer. It is also possible to run all of these scripts in
+iOS. You'll need to download an app with Python 2.7X or later. Then
+you will need to make sure that the app can open Python files from other
+apps. It is possible to store this repository onto your own personal
+Dropbox folder, so you can import them into your python app
+easily. Some apps might support ZIP files, in which case all you would
+need to do to open all the files at once is to open the zip package
+and unzip it with commands on the app. Please note: I wrote these
+files on a Windows 8.1 laptop. I don't know for sure if your other
+operating system will work with these programs, but I tried to
+eliminate all the modules that require a certain operating system.
 
 ##Contributing
-In order to contribute, please fork your own copy of this repository. This way, your changes will not affect this repository. To contribute your own code, you can, after you fork this repository and make your changes, send me a message on github with the link of your repository, so I can test out your code, and send you a pull request if the code has no issues with it. Also, please provide a detailed explanation of what you've changed.
 
-##Translaters.
-I don't know any other languages other than English and Spannish, and I don't know any other programming languages other than Python 2.7X. Please help by translating int your native languages, and also to other programming languages. Please remember to fork this repository so your changes don't affect this repository!
+In order to contribute, please fork your own copy of this
+repository. This way, your changes will not affect this repository. To
+contribute your own code, you can, after you fork this repository and
+make your changes, send me a message on GitHub with the link of your
+repository, so I can test out your code, and send you a pull request
+if the code has no issues with it. Also, please provide a detailed
+explanation of what you've changed.
 
-##Reporting issues/bugs
-You can use the github website to do this. Notes to myself: To be written, unsure of how to do this yet.
+##Translators
+
+I don't know any other languages other than English and Spanish, and
+I don't know any other programming languages other than Python
+2.7X. Please help by translating into your native languages, and also
+to other programming languages. Please remember to fork this
+repository so your changes don't affect this repository!
+
+##Reporting Issues/Bugs
+
+You can use the GitHub website to do this. Notes to myself: To be
+written, unsure of how to do this yet.


### PR DESCRIPTION
Added blank lines after headers.
Wrapped paragraphs to 72 charactors (to keep source text on screen. Does not affect output.).
Spell Check. "int" to "into". "half" to "have"
Made headers Camel Case (capitalize significant words, but not "to" , "a", "and", etc.)

Lawrence, I understand the process better now, I think. A fork is required to allow GitHub to access both repositories. I forgot to branch again on this attempt, so you won't have to merge, just pull. GitHub can see that the merge will work smoothly as we have no conflicts at the moment.
